### PR TITLE
Add Rolemaster Unified system detection

### DIFF
--- a/scripts/tokens/system-detection.js
+++ b/scripts/tokens/system-detection.js
@@ -154,7 +154,7 @@ const ACTOR_TYPE_MAPPINGS = {
   // Rolemaster Unified
   'rmu': {
     defaultType: 'Creature',
-    supportedTypes: ['Creature','Character'],
+    supportedTypes: ['Creature','Character'], 
     requiredFields: ['name', 'type'],
     optionalFields: ['img'],
     description: 'Rolemaster Unified'

--- a/scripts/tokens/system-detection.js
+++ b/scripts/tokens/system-detection.js
@@ -151,6 +151,15 @@ const ACTOR_TYPE_MAPPINGS = {
     description: 'Shadowdark RPG'
   },
 
+  // Rolemaster Unified
+  'rmu': {
+    defaultType: 'Creature',
+    supportedTypes: ['Creature'],
+    requiredFields: ['name', 'type'],
+    optionalFields: ['img'],
+    description: 'Rolemaster Unified'
+  },
+
   // Generic fallback for unknown systems
   'generic': {
     defaultType: 'character',

--- a/scripts/tokens/system-detection.js
+++ b/scripts/tokens/system-detection.js
@@ -154,7 +154,7 @@ const ACTOR_TYPE_MAPPINGS = {
   // Rolemaster Unified
   'rmu': {
     defaultType: 'Creature',
-    supportedTypes: ['Creature'],
+    supportedTypes: ['Creature','Character'],
     requiredFields: ['name', 'type'],
     optionalFields: ['img'],
     description: 'Rolemaster Unified'


### PR DESCRIPTION
This snippet will add support for Rolemaster Unified.

Creature actor type is a catch-all for both NPC and Creatures.

I'm the developer of RMU system for Iron Crown.  I've test this detection and it works as expected.


https://github.com/user-attachments/assets/6f88bf94-6d60-4f43-8166-7df4fbc58ded

