### PR TITLE
Simplify token variant regex and allow 3 letters

### DIFF
--- a/scripts/content/inventory-utils.js
+++ b/scripts/content/inventory-utils.js
@@ -102,7 +102,7 @@ export function parseTokenDisplayName(filename = '') {
   let variant = '';
   for (let i = 0; i < parts.length; i++) {
     const p = parts[i];
-    if (/^[A-Z]{1,3}\d{1,3}$/.test(p) || /^\d{3}[A-Z]$/.test(p)) {
+    if (/^([A-Z]{1,3}\d+|\d{3}[A-Z])$/.test(p)) {
       variantIndex = i;
       variant = p;
       break;


### PR DESCRIPTION
This module is turning out awesome for navigating both the official FA tokens and the ones I've gotten from the FA Discord server. I like to organise these fan-made tokens in a similar manner to the official tokens, by naming the variants `_FAN1_` `_FAN2_`, etc. Unfortunately, this module only allows for 2 capital letters to be used for variants.

With this PR, I simplified the regex that is used to recognize token variants and made it so it allows for up to three capital letters followed by numbers, instead of only 1 or 2 capital letters.

This removes some duplicate regex tests, i.e. `/^[A-Z]\d+$/` already returns a positive match for everything `/^[A-Z]\d{2,}$/` would match.