### PR TITLE
Fix Shift+Wheel scaling on macOS

### DIFF
--- a/scripts/assets/asset-placement-manager.js
+++ b/scripts/assets/asset-placement-manager.js
@@ -5182,7 +5182,9 @@ export class AssetPlacementManager {
           event.stopPropagation();
           event.stopImmediatePropagation?.();
           const step = 1.05;
-          const dir = event.deltaY < 0 ? 1 : -1;
+          // macOS converts Shift+Wheel to horizontal scroll, zeroing deltaY
+          const delta = event.deltaY || event.deltaX;
+          const dir = delta < 0 ? 1 : -1;
           if (this._scatterMode === ASSET_SCATTER_MODE_BRUSH) {
             const current = this._getScatterBrushSize();
             let next = current * Math.pow(step, dir);


### PR DESCRIPTION
## Analysis

On macOS, holding Shift while scrolling with a mouse wheel is a system-level shortcut that converts vertical scroll into horizontal scroll. The OS zeros out deltaY and moves the value to deltaX. This does not happen with trackpads, and does not happen on Windows or Linux.

The scaling handler reads event.deltaY to determine direction. Since deltaY is always 0 on macOS with an external mouse, the ternary event.deltaY < 0 ? 1 : -1 always evaluates to -1 (scale down), regardless of which way the wheel turns.

Rotation (Ctrl/Cmd+Wheel) is unaffected because macOS only applies the axis conversion for the Shift modifier specifically.

### Existing handling elsewhere in FA Nexus

tool-options-controller.js already accounts for this with Number(event.deltaY) || Number(event.deltaX), falling back to the horizontal axis when the vertical axis is zero.

## Proposed fix

In asset-placement-manager.js, in the Shift+Wheel scaling handler, replace:

const dir = event.deltaY < 0 ? 1 : -1;

with:

const delta = event.deltaY || event.deltaX;
const dir = delta < 0 ? 1 : -1;

This matches the existing pattern in the codebase and fixes scaling for external mice on macOS without changing behavior on other platforms.